### PR TITLE
Bad parsing on unique values with %

### DIFF
--- a/lib/modules/category-parsers/dofus-touch/services/format-helpers.js
+++ b/lib/modules/category-parsers/dofus-touch/services/format-helpers.js
@@ -5,7 +5,7 @@ module.exports = {
 	},
 
 	getElement: (stat) => {
-		const regex = /(-?\d+) ((de|à|to|and)? (-?\d+))?/gi;
+		const regex = /(-?\d+)\s((de|à|to|and)? (-?\d+))?/gi;
 		return stat.replace(regex, '').trim();
 	},
 

--- a/lib/modules/category-parsers/dofus-touch/services/helpers.spec.js
+++ b/lib/modules/category-parsers/dofus-touch/services/helpers.spec.js
@@ -31,6 +31,10 @@ describe('parse element from item stat', () => {
 		runTest('15 Prospection', 'Prospection');
 	});
 
+	test('stat starting with a percent', () => {
+		runTest('15% Dommages mêlée', '% Dommages mêlée');
+	});
+	
 	test('stat with parenthesis like weapon damages', () => {
 		runTest('9 à 14 (dommages Neutre)', '(dommages Neutre)');
 	});

--- a/lib/modules/category-parsers/dofus/services/format-helpers.js
+++ b/lib/modules/category-parsers/dofus/services/format-helpers.js
@@ -5,7 +5,7 @@ module.exports = {
 	},
 
 	getElement: (stat) => {
-		const regex = /(-?\d+) ((de|à|to|and)? (-?\d+))?/gi;
+		const regex = /(-?\d+)\s?((de|à|to|and)? (-?\d+))?/gi;
 		return stat.replace(regex, '').trim();
 	},
 

--- a/lib/modules/category-parsers/dofus/services/helpers.spec.js
+++ b/lib/modules/category-parsers/dofus/services/helpers.spec.js
@@ -31,6 +31,10 @@ describe('parse element from item stat', () => {
 		runTest('15 Prospection', 'Prospection');
 	});
 
+	test('stat starting with a percent', () => {
+		runTest('15% Dommages mêlée', '% Dommages mêlée');
+	});
+
 	test('stat with parenthesis like weapon damages', () => {
 		runTest('9 à 14 (dommages Neutre)', '(dommages Neutre)');
 	});


### PR DESCRIPTION
Example:
15% Critical 
- before => stat name = 15% Critical { min: 15, max: null }
- after => stat name = % Critical { min: 15, max: null }


-- 
I would like to PR a change to get { min: 15, max: 15 } for every unique value, would you accept it ?

Thanks